### PR TITLE
Tradução da documentação database

### DIFF
--- a/database.md
+++ b/database.md
@@ -1,48 +1,48 @@
-# Basic Database Usage
+# Uso básico do banco de dados
 
-- [Configuration](#configuration)
-- [Running Queries](#running-queries)
-- [Accessing Connections](#accessing-connections)
+- [Configuração](#configuration)
+- [Executando Queries](#running-queries)
+- [Conexões de Acesso](#accessing-connections)
 
 <a name="configuration"></a>
-## Configuration
+## Configuração
 
-Laravel makes connecting with databases and running queries extremely simple. The database configuration file is `app/config/database.php`. In this file you may define all of your database connections, as well as specify which connection should be used by default. Examples for all of the supported database systems are provided in this file.
+Laravel torna a conexão com o banco de dados e execução de queries extremamente simples. O arquivo de configuração do banco de dados é `app/config/database.php`. Neste arquivo você pode definir todas suas conexões com o banco de dados, bem como especificar qual conexão deve ser usada como padrão. Exemplos para todos os sistemas de bancos de dados suportados estão neste arquivo.
 
-Currently Laravel supports four database systems: MySQL, Postgres, SQLite, and SQL Server.
+Atualmente Laravel suporta quatro tipos de sistemas de bancos de dados: MySQL, Postgres, SQLite, e SQL Server.
 
 <a name="running-queries"></a>
-## Running Queries
+## Executando Queries
 
-Once you have configured your database connection, you may run queries using the `DB` class.
+Depois de ter configurado a conexão com o banco de dados, você pode executar queries usando a classe `DB`.
 
-**Running A Select Query**
+**Executando uma Query de Select**
 
 	$results = DB::select('select * from users where id = ?', array(1));
 
-The `select` method will always return an `array` of results.
+O método `select` irá sempre retornar um `array` de resultados.
 
-**Running An Insert Statement**
+**Executando uma instrução de Insert**
 
 	DB::insert('insert into users (id, name) values (?, ?)', array(1, 'Dayle'));
 
-**Running An Update Statement**
+**Executando uma instrução de Update**
 
 	DB::update('update users set votes = 100 where name = ?', array('John'));
 
-**Running A Delete Statement**
+**Executando uma instrução de Delete**
 
 	DB::delete('delete from users');
 
-> **Note:** The `update` and `delete` statements return the number of rows affected by the operation.
+> **Nota:** As instruções de `update` e `delete` retornam o número de linhas afetadas pela operação.
 
-**Running A General Statement**
+**Executando uma instrução geral**
 
 	DB::statement('drop table users');
 
-You may listen for query events using the `DB::listen` method:
+Você pode "escutar" por eventos de query usando o método `DB::listen`:
 
-**Listening For Query Events**
+**"Escutando" eventos de query**
 
 	DB::listen(function($sql, $bindings, $time)
 	{
@@ -50,8 +50,8 @@ You may listen for query events using the `DB::listen` method:
 	});
 
 <a name="accessing-connections"></a>
-## Accessing Connections
+## Conexões de Acesso
 
-When using multiple connections, you may access them via the `DB::connection` method:
+Quando utilizar multiplas conexões, você pode acessá-las através do método `DB::connection`:
 
 	$users = DB::connection('foo')->select(...);


### PR DESCRIPTION
Mantive "query" como "query", não traduzi. E não achei outra palavra para traduzir "listen for events", então coloquei "escutar" entre aspas.
